### PR TITLE
Prevent double fragment in service endpoint URL.

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,6 +480,8 @@ dereference ( didUrl, dereferenceOptions ) <br>
 			and the <var>input <a>DID URL</a></var> contains a <a>DID fragment</a>:
 			<pre class="example nohighlight">did:example:1234?service=files&relativeRef=%2Fmyresume%2Fdoc%3Fversion%3Dlatest#intro</pre>
 			<ol class="algorithm">
+				<li>If the <var>output <a>service endpoint</a> URL</var>
+				contains a <code>fragment</code> component, raise an error.</li>
 				<li>Append the <a>DID fragment</a> to the <var>output <a>service endpoint</a> URL</var>. In other words,
 				the <var>output <a>service endpoint</a> URL</var> "inherits" the <a>DID fragment</a> of the
 				<var>input <a>DID URL</a></var>.</li>


### PR DESCRIPTION
This adds a check to ensure that an *output service endpoint URL* does not have two fragment components. This is equivalent to the requirement in [Service Endpoint Construction](https://w3c-ccg.github.io/did-resolution/#input) that "the input DID URL and input service endpoint URL MUST NOT both have a fragment component". The reason to add it here is because when the Service Endpoint Construction algorithm is called (in Step 1.2 of [Dereferencing the Primary Resource](https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm-primary)), the *input DID URL* has already had its fragment removed (in Step 2 of the [DID URL dereferencing algorithm](https://w3c-ccg.github.io/did-resolution/#dereferencing), so the existing check is not effectual. The removed fragment is appended to the *output service endpoint URL* in [Dereferencing the Secondary Resource](https://w3c-ccg.github.io/did-resolution/#dereferencing-algorithm-secondary) (Step 2.1), so this PR adds the check there.