### PR TITLE
Add did key errors to spec.

### DIFF
--- a/index.html
+++ b/index.html
@@ -944,6 +944,22 @@ https://example.com/messages/8377464/some/path?query#frag
 	<h2>internalError</h2>
 	<p>When an unexpected error occurs during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
 		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>internalError</strong>.
+	<h2>invalidPublicKeyLength</h2>
+	<p>If the byte length of <i>rawPublicKeyBytes</i> does not match the expected public key length for the associated multicodecValue during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKeyLength</strong>.
+	<h2>invalidPublicKey</h2>
+	<p>If an invalid public key value is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKey</strong>.
+	<h2>invalidDidUrl</h2>
+	<p>If an invalid DID URL is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidDidUrl</strong>.
+	<h2>unsupportedPublicKeyType</h2>
+	<p>If an unsupported public key type is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>unsupportedPublicKeyType</strong>.
+	<h2>invalidPublicKeyType</h2>
+	<p>If an invalid public key type is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKeyType</strong>.
+
 </section>
 
 <section id="bindings">

--- a/index.html
+++ b/index.html
@@ -941,24 +941,41 @@ https://example.com/messages/8377464/some/path?query#frag
 
 <section id="errors">
 	<h1>Errors</h1>
+    <h2>invalidDid</h2>
+	<p>If an invalid DID is detected during <a>DID Resolution</a>,
+		the value of the DID Resolution Metadata <strong>error</strong> property MUST be <strong>invalidDid</strong>
+        as defined in <a href="https://www.w3.org/TR/did-core/#did-resolution-metadata">did-core</a>.
+    </p>
+	<h2>invalidDidUrl</h2>
+	<p>If an invalid DID URL is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidDidUrl</strong>
+        as defined in <a href="https://www.w3.org/TR/did-core/#did-resolution-metadata">did-core</a>.
+    </p>
 	<h2>internalError</h2>
 	<p>When an unexpected error occurs during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
 		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>internalError</strong>.
-	<h2>invalidPublicKeyLength</h2>
-	<p>If the byte length of <i>rawPublicKeyBytes</i> does not match the expected public key length for the associated multicodecValue during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKeyLength</strong>.
+    </p>
 	<h2>invalidPublicKey</h2>
 	<p>If an invalid public key value is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
 		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKey</strong>.
-	<h2>invalidDidUrl</h2>
-	<p>If an invalid DID URL is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidDidUrl</strong>.
-	<h2>unsupportedPublicKeyType</h2>
-	<p>If an unsupported public key type is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
-		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>unsupportedPublicKeyType</strong>.
+    </p>
+	<h2>invalidPublicKeyLength</h2>
+	<p>If the byte length of <i>rawPublicKeyBytes</i> does not match the expected public key length for the associated multicodecValue during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKeyLength</strong>.
+    </p>
 	<h2>invalidPublicKeyType</h2>
 	<p>If an invalid public key type is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
 		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKeyType</strong>.
+    </p>
+    <h2>notFound</h2>
+    <p> If during <a>DID Resolution</a> or <a>DID URL dereferencing</a> a DID or DID URL doesn't exist,
+        the value of the DID Resolution or DID URL dereferencing Metadata <strong>error</strong> property MUST be <strong>notFound</strong> as
+        defined in <a href="https://www.w3.org/TR/did-core/#did-resolution-metadata">did-core</a>.
+    </p>
+	<h2>unsupportedPublicKeyType</h2>
+	<p>If an unsupported public key type is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>unsupportedPublicKeyType</strong>.
+    </p>
 
 </section>
 


### PR DESCRIPTION
Adds errors from the [did key spec](https://w3c-ccg.github.io/did-method-key/) to the did resolution.

Errors added:

- invalidPublicKeyLength
- invalidPublicKey
- invalidDidUrl
- unsupportedPublicKeyType
- invalidPublicKeyType