### PR TITLE
Add methodNotSupported to "Errors" section.

### DIFF
--- a/index.html
+++ b/index.html
@@ -966,6 +966,10 @@ https://example.com/messages/8377464/some/path?query#frag
 	<p>When an unexpected error occurs during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
 		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>internalError</strong>.
     </p>
+	<h2>methodNotSupported</h2>
+	<p> If a DID method is not supported during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
+		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>methodNotSupported</strong>.
+	</p>
 	<h2>invalidPublicKey</h2>
 	<p>If an invalid public key value is detected during <a>DID Resolution</a> or <a>DID URL dereferencing</a>,
 		the value of the DID Resolution or DID URL Dereferencing Metadata <strong>error</strong> property MUST be <strong>invalidPublicKey</strong>.


### PR DESCRIPTION
The "methodNotSupported" error is being mentioned in the DID Resolution algorithm section (see https://w3c-ccg.github.io/did-resolution/#resolving-algorithm), but it's currently missing in the "Errors" section (see https://w3c-ccg.github.io/did-resolution/#errors).

Related to https://github.com/w3c-ccg/did-resolution/issues/72.